### PR TITLE
Add TypeScript plugin

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,8 +9,8 @@
   "scripts": {
     "release": "yarn build:all && changeset publish",
     "benchmark": "yarn workspace astro run benchmark",
-    "build": "lerna run build --scope \"{@astrojs/language-server,astro-vscode}\"",
-    "dev": "lerna run dev --scope \"{@astrojs/language-server,astro-vscode}\" --parallel --stream",
+    "build": "lerna run build --scope \"{@astrojs/language-server,astro-vscode,@astrojs/ts-plugin}\"",
+    "dev": "lerna run dev --scope \"{@astrojs/language-server,astro-vscode,@astrojs/ts-plugin}\" --parallel --stream",
     "format": "prettier -w .",
     "lint": "eslint \"packages/**/*.ts\"",
     "test": "yarn workspace @astrojs/vscode run test"

--- a/packages/language-server/src/plugins/astro/AstroPlugin.ts
+++ b/packages/language-server/src/plugins/astro/AstroPlugin.ts
@@ -102,7 +102,7 @@ export class AstroPlugin implements CompletionsProvider, FoldingRangeProvider {
     const { lang } = await this.tsLanguageServiceManager.getTypeScriptDoc(document);
     const defs = this.getDefinitionsForComponentName(document, lang, componentName);
 
-    if (!defs) {
+    if (!defs || !defs.length) {
       return [];
     }
 
@@ -190,7 +190,7 @@ export class AstroPlugin implements CompletionsProvider, FoldingRangeProvider {
 
     const defs = this.getDefinitionsForComponentName(document, thisLang, componentName);
 
-    if (!defs) {
+    if (!defs || !defs.length) {
       return [];
     }
 

--- a/packages/ts-plugin/astro.d.ts
+++ b/packages/ts-plugin/astro.d.ts
@@ -1,0 +1,25 @@
+type AstroRenderedHTML = string;
+
+type FetchContentResult<ContentFrontmatter extends Record<string, any> = Record<string, any>> = {
+  astro: {
+    headers: string[];
+    source: string;
+    html: AstroRenderedHTML;
+  };
+  url: URL;
+} & ContentFrontmatter;
+
+interface AstroPageRequest {
+  url: URL;
+  canonicalURL: URL;
+}
+
+interface Astro {
+  isPage: boolean;
+  fetchContent<ContentFrontmatter>(globStr: string): FetchContentResult<ContentFrontmatter>[];
+  props: Record<string, number | string | any>;
+  request: AstroPageRequest;
+  site: URL;
+}
+
+declare const Astro: Astro;

--- a/packages/ts-plugin/package.json
+++ b/packages/ts-plugin/package.json
@@ -1,27 +1,28 @@
 {
-  "name": "@astrojs/ts-plugin",
-  "version": "0.1.0",
-  "description": "A TypeScript Plugin providing Astro intellisense",
-  "main": "dist/index.js",
-  "type": "commonjs",
-  "keywords": [
-      "astro",
-      "typescript",
-      "javascript",
-      "plugin"
-  ],
-  "scripts": {
-    "build": "astro-scripts build \"src/**/*.ts\"",
-    "dev": "astro-scripts dev \"src/**/*.ts\""
-  },
-  "author": "Skypack",
-  "license": "MIT",
-  "devDependencies": {
-      "@tsconfig/node12": "^1.0.0",
-      "@types/node": "^13.9.0",
-      "typescript": "*"
-  },
-  "dependencies": {
-      "sourcemap-codec": "^1.4.8"
-  }
+    "name": "@astrojs/ts-plugin",
+    "version": "0.1.0",
+    "description": "A TypeScript Plugin providing Astro intellisense",
+    "main": "dist/index.js",
+    "type": "commonjs",
+    "keywords": [
+        "astro",
+        "typescript",
+        "javascript",
+        "plugin"
+    ],
+    "scripts": {
+        "build": "astro-scripts build \"src/**/*.ts\"",
+        "dev": "astro-scripts dev \"src/**/*.ts\""
+    },
+    "author": "Skypack",
+    "license": "MIT",
+    "devDependencies": {
+        "@tsconfig/node12": "^1.0.0",
+        "@types/node": "^13.9.0",
+        "typescript": "*"
+    },
+    "dependencies": {
+        "sourcemap-codec": "^1.4.8",
+        "ts-morph": "^12.0.0"
+    }
 }

--- a/packages/ts-plugin/package.json
+++ b/packages/ts-plugin/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "@astrojs/ts-plugin",
+  "version": "0.1.0",
+  "description": "A TypeScript Plugin providing Astro intellisense",
+  "main": "dist/index.js",
+  "type": "commonjs",
+  "keywords": [
+      "astro",
+      "typescript",
+      "javascript",
+      "plugin"
+  ],
+  "scripts": {
+    "build": "astro-scripts build \"src/**/*.ts\"",
+    "dev": "astro-scripts dev \"src/**/*.ts\""
+  },
+  "author": "Skypack",
+  "license": "MIT",
+  "devDependencies": {
+      "@tsconfig/node12": "^1.0.0",
+      "@types/node": "^13.9.0",
+      "typescript": "*"
+  },
+  "dependencies": {
+      "sourcemap-codec": "^1.4.8"
+  }
+}

--- a/packages/ts-plugin/src/astro-snapshots.ts
+++ b/packages/ts-plugin/src/astro-snapshots.ts
@@ -262,7 +262,7 @@ export class AstroSnapshotManager {
                 this.logger.debug('Read Astro file:', path);
                 const astroCode = readFile(path) || '';
                 try {
-                    const isTsFile = true; // TODO check file contents? TS might be okay with importing ts into js.
+                    const isTsFile = true;
                     const result = astro2tsx(astroCode, {
                         filename: path.split('/').pop(),
                         isTsFile

--- a/packages/ts-plugin/src/astro-snapshots.ts
+++ b/packages/ts-plugin/src/astro-snapshots.ts
@@ -1,0 +1,297 @@
+import { astro2tsx } from './astro2tsx.js';
+import type ts from 'typescript/lib/tsserverlibrary';
+import { Logger } from './logger.js';
+import { SourceMapper } from './source-mapper.js';
+import { isNoTextSpanInGeneratedCode, isAstroFilePath } from './utils.js';
+
+export class AstroSnapshot {
+    private scriptInfo?: ts.server.ScriptInfo;
+    private lineOffsets?: number[];
+    private convertInternalCodePositions = false;
+
+    constructor(
+        private typescript: typeof ts,
+        private fileName: string,
+        private astroCode: string,
+        private mapper: SourceMapper,
+        private logger: Logger,
+        public readonly isTsFile: boolean
+    ) {}
+
+    update(astroCode: string, mapper: SourceMapper) {
+        this.astroCode = astroCode;
+        this.mapper = mapper;
+        this.lineOffsets = undefined;
+        this.log('Updated Snapshot');
+    }
+
+    getOriginalTextSpan(textSpan: ts.TextSpan): ts.TextSpan | null {
+        if (!isNoTextSpanInGeneratedCode(this.getText(), textSpan)) {
+            return null;
+        }
+
+        const start = this.getOriginalOffset(textSpan.start);
+        if (start === -1) {
+            return null;
+        }
+
+        // Assumption: We don't change identifiers itself, so we don't change ranges.
+        return {
+            start,
+            length: textSpan.length
+        };
+    }
+
+    getOriginalOffset(generatedOffset: number) {
+        if (!this.scriptInfo) {
+            return generatedOffset;
+        }
+
+        this.toggleMappingMode(true);
+        const lineOffset = this.scriptInfo.positionToLineOffset(generatedOffset);
+        this.debug('try convert offset', generatedOffset, '/', lineOffset);
+        const original = this.mapper.getOriginalPosition({
+            line: lineOffset.line - 1,
+            character: lineOffset.offset - 1
+        });
+        this.toggleMappingMode(false);
+        if (original.line === -1) {
+            return -1;
+        }
+
+        const originalOffset = this.scriptInfo.lineOffsetToPosition(
+            original.line + 1,
+            original.character + 1
+        );
+        this.debug('converted offset to', original, '/', originalOffset);
+        return originalOffset;
+    }
+
+    setAndPatchScriptInfo(scriptInfo: ts.server.ScriptInfo) {
+        // @ts-expect-error
+        scriptInfo.scriptKind = this.typescript.ScriptKind.TSX;
+
+        const positionToLineOffset = scriptInfo.positionToLineOffset.bind(scriptInfo);
+        scriptInfo.positionToLineOffset = (position) => {
+            if (this.convertInternalCodePositions) {
+                const lineOffset = positionToLineOffset(position);
+                this.debug('positionToLineOffset for generated code', position, lineOffset);
+                return lineOffset;
+            }
+
+            const lineOffset = this.positionAt(position);
+            this.debug('positionToLineOffset for original code', position, lineOffset);
+            return { line: lineOffset.line + 1, offset: lineOffset.character + 1 };
+        };
+
+        const lineOffsetToPosition = scriptInfo.lineOffsetToPosition.bind(scriptInfo);
+        scriptInfo.lineOffsetToPosition = (line, offset) => {
+            if (this.convertInternalCodePositions) {
+                const position = lineOffsetToPosition(line, offset);
+                this.debug('lineOffsetToPosition for generated code', { line, offset }, position);
+                return position;
+            }
+
+            const position = this.offsetAt({ line: line - 1, character: offset - 1 });
+            this.debug('lineOffsetToPosition for original code', { line, offset }, position);
+            return position;
+        };
+
+        this.scriptInfo = scriptInfo;
+        this.log('patched scriptInfo');
+    }
+
+    /**
+     * Get the line and character based on the offset
+     * @param offset The index of the position
+     */
+    positionAt(offset: number): ts.LineAndCharacter {
+        offset = this.clamp(offset, 0, this.astroCode.length);
+
+        const lineOffsets = this.getLineOffsets();
+        let low = 0;
+        let high = lineOffsets.length;
+        if (high === 0) {
+            return { line: 0, character: offset };
+        }
+
+        while (low < high) {
+            const mid = Math.floor((low + high) / 2);
+            if (lineOffsets[mid] > offset) {
+                high = mid;
+            } else {
+                low = mid + 1;
+            }
+        }
+
+        // low is the least x for which the line offset is larger than the current offset
+        // or array.length if no line offset is larger than the current offset
+        const line = low - 1;
+
+        return { line, character: offset - lineOffsets[line] };
+    }
+
+    /**
+     * Get the index of the line and character position
+     * @param position Line and character position
+     */
+    offsetAt(position: ts.LineAndCharacter): number {
+        const lineOffsets = this.getLineOffsets();
+
+        if (position.line >= lineOffsets.length) {
+            return this.astroCode.length;
+        } else if (position.line < 0) {
+            return 0;
+        }
+
+        const lineOffset = lineOffsets[position.line];
+        const nextLineOffset =
+            position.line + 1 < lineOffsets.length
+                ? lineOffsets[position.line + 1]
+                : this.astroCode.length;
+
+        return this.clamp(nextLineOffset, lineOffset, lineOffset + position.character);
+    }
+
+    private getLineOffsets() {
+        if (this.lineOffsets) {
+            return this.lineOffsets;
+        }
+
+        const lineOffsets = [];
+        const text = this.astroCode;
+        let isLineStart = true;
+
+        for (let i = 0; i < text.length; i++) {
+            if (isLineStart) {
+                lineOffsets.push(i);
+                isLineStart = false;
+            }
+            const ch = text.charAt(i);
+            isLineStart = ch === '\r' || ch === '\n';
+            if (ch === '\r' && i + 1 < text.length && text.charAt(i + 1) === '\n') {
+                i++;
+            }
+        }
+
+        if (isLineStart && text.length > 0) {
+            lineOffsets.push(text.length);
+        }
+
+        this.lineOffsets = lineOffsets;
+        return lineOffsets;
+    }
+
+    private clamp(num: number, min: number, max: number): number {
+        return Math.max(min, Math.min(max, num));
+    }
+
+    private log(...args: any[]) {
+        this.logger.log('AstroSnapshot:', this.fileName, '-', ...args);
+    }
+
+    private debug(...args: any[]) {
+        this.logger.debug('AstroSnapshot:', this.fileName, '-', ...args);
+    }
+
+    private toggleMappingMode(convertInternalCodePositions: boolean) {
+        this.convertInternalCodePositions = convertInternalCodePositions;
+    }
+
+    private getText() {
+        const snapshot = this.scriptInfo?.getSnapshot();
+        if (!snapshot) {
+            return '';
+        }
+        return snapshot.getText(0, snapshot.getLength());
+    }
+}
+
+export class AstroSnapshotManager {
+    private snapshots = new Map<string, AstroSnapshot>();
+
+    constructor(
+        private typescript: typeof ts,
+        private projectService: ts.server.ProjectService,
+        private logger: Logger
+    ) {
+        this.patchProjectServiceReadFile();
+    }
+
+    get(fileName: string) {
+        return this.snapshots.get(fileName);
+    }
+
+    create(fileName: string): AstroSnapshot | undefined {
+        if (this.snapshots.has(fileName)) {
+            return this.snapshots.get(fileName)!;
+        }
+
+        // This will trigger projectService.host.readFile which is patched below
+        const scriptInfo = this.projectService.getOrCreateScriptInfoForNormalizedPath(
+            this.typescript.server.toNormalizedPath(fileName),
+            false
+        );
+        if (!scriptInfo) {
+            this.logger.log('Was not able get snapshot for', fileName);
+            return;
+        }
+
+        try {
+            scriptInfo.getSnapshot(); // needed to trigger readFile
+        } catch (e) {
+            this.logger.log('Loading Snapshot failed', fileName);
+        }
+        const snapshot = this.snapshots.get(fileName);
+        if (!snapshot) {
+            this.logger.log(
+                'Astro snapshot was not found after trying to load script snapshot for',
+                fileName
+            );
+            return; // should never get here
+        }
+        snapshot.setAndPatchScriptInfo(scriptInfo);
+        this.snapshots.set(fileName, snapshot);
+        return snapshot;
+    }
+
+    private patchProjectServiceReadFile() {
+        const readFile = this.projectService.host.readFile;
+        this.projectService.host.readFile = (path: string) => {
+            if (isAstroFilePath(path)) {
+                this.logger.debug('Read Astro file:', path);
+                const astroCode = readFile(path) || '';
+                try {
+                    const isTsFile = true; // TODO check file contents? TS might be okay with importing ts into js.
+                    const result = astro2tsx(astroCode, {
+                        filename: path.split('/').pop(),
+                        isTsFile
+                    });
+                    const existingSnapshot = this.snapshots.get(path);
+                    if (existingSnapshot) {
+                        existingSnapshot.update(astroCode, new SourceMapper(result.map.mappings));
+                    } else {
+                        this.snapshots.set(
+                            path,
+                            new AstroSnapshot(
+                                this.typescript,
+                                path,
+                                astroCode,
+                                new SourceMapper(result.map.mappings),
+                                this.logger,
+                                isTsFile
+                            )
+                        );
+                    }
+                    this.logger.log('Successfully read Astro file contents of', path);
+                    return result.code;
+                } catch (e) {
+                    this.logger.log('Error loading Astro file:', path);
+                    this.logger.debug('Error:', e);
+                }
+            } else {
+                return readFile(path);
+            }
+        };
+    }
+}

--- a/packages/ts-plugin/src/astro-sys.ts
+++ b/packages/ts-plugin/src/astro-sys.ts
@@ -1,0 +1,32 @@
+import ts from 'typescript';
+import { Logger } from './logger.js';
+import { ensureRealAstroFilePath, isVirtualAstroFilePath, toRealAstroFilePath } from './utils.js';
+
+/**
+ * This should only be accessed by TS svelte module resolution.
+ */
+export function createAstroSys(logger: Logger) {
+    const astroSys: ts.System = {
+        ...ts.sys,
+        fileExists(path: string) {
+            return ts.sys.fileExists(ensureRealAstroFilePath(path));
+        },
+        readDirectory(path, extensions, exclude, include, depth) {
+            const extensionsWithAstro = (extensions ?? []).concat('.astro');
+
+            return ts.sys.readDirectory(path, extensionsWithAstro, exclude, include, depth);
+        }
+    };
+
+    if (ts.sys.realpath) {
+        const realpath = ts.sys.realpath;
+        astroSys.realpath = function (path) {
+            if (isVirtualAstroFilePath(path)) {
+                return realpath(toRealAstroFilePath(path)) + '.ts';
+            }
+            return realpath(path);
+        };
+    }
+
+    return astroSys;
+}

--- a/packages/ts-plugin/src/astro-sys.ts
+++ b/packages/ts-plugin/src/astro-sys.ts
@@ -3,7 +3,7 @@ import { Logger } from './logger.js';
 import { ensureRealAstroFilePath, isVirtualAstroFilePath, toRealAstroFilePath } from './utils.js';
 
 /**
- * This should only be accessed by TS svelte module resolution.
+ * This should only be accessed by TS astro module resolution.
  */
 export function createAstroSys(logger: Logger) {
     const astroSys: ts.System = {

--- a/packages/ts-plugin/src/astro2tsx.ts
+++ b/packages/ts-plugin/src/astro2tsx.ts
@@ -1,0 +1,49 @@
+import type { FileMapping } from './source-mapper';
+import { readFileSync } from 'fs';
+
+const ASTRO_DEFINITION = readFileSync(require.resolve('../astro.d.ts'));
+
+// Note that this is a bit of a hack until the new compiler with proper
+// source map support.
+
+interface Astro2TSXOptions {
+  filename: string | undefined;
+  isTsFile: boolean;
+}
+
+interface Astro2TSXResult {
+  code: string;
+  map: {
+    mappings: FileMapping
+  }
+}
+
+export function astro2tsx(code: string, options: Astro2TSXOptions): Astro2TSXResult {
+  const compiled =  transformContent(code);
+
+  const result: Astro2TSXResult = {
+    code: compiled,
+    map: {
+      mappings: []
+    }
+  };
+  
+  return result;
+}
+
+// This is hacky but it works for now
+function addProps(content: string, dtsContent: string): string {
+  let defaultExportType = 'Record<string, any>';
+  if(/interface Props/.test(content)) {
+    defaultExportType = 'Props';
+  }
+  return dtsContent + '\n' + `export default function (props: ${defaultExportType}): string;`
+}
+
+function transformContent(content: string) {
+  return (
+    content.replace(/---/g, '///') +
+    // Add TypeScript definitions
+    addProps(content, ASTRO_DEFINITION.toString('utf-8'))
+  );
+}

--- a/packages/ts-plugin/src/index.ts
+++ b/packages/ts-plugin/src/index.ts
@@ -1,0 +1,76 @@
+import type ts from 'typescript/lib/tsserverlibrary';
+import { dirname, resolve } from 'path';
+import { decorateLanguageService } from './language-service/index.js';
+import { Logger } from './logger.js';
+import { patchModuleLoader } from './module-loader.js';
+import { AstroSnapshotManager } from './astro-snapshots.js';
+
+function init(modules: { typescript: typeof ts }) {
+  function create(info: ts.server.PluginCreateInfo) {
+    const logger = new Logger(info.project.projectService.logger);
+
+    if (!isAstroProject(info)) {
+        logger.log('Detected that this is not an Astro project, abort patching TypeScript');
+        return info.languageService;
+    }
+
+    logger.log('Starting Astro plugin');
+
+    const snapshotManager = new AstroSnapshotManager(
+        modules.typescript,
+        info.project.projectService,
+        logger
+    );
+
+    patchCompilerOptions(info.project);
+    patchModuleLoader(
+        logger,
+        snapshotManager,
+        modules.typescript,
+        info.languageServiceHost,
+        info.project
+    );
+    return decorateLanguageService(info.languageService, snapshotManager, logger);
+  }
+
+  function getExternalFiles(_project: ts.server.ConfiguredProject) {
+      // Needed so the ambient definitions are known inside the tsx files
+      /*const svelteTsPath = dirname(require.resolve('svelte2tsx'));
+      const svelteTsxFiles = [
+          './svelte-shims.d.ts',
+          './svelte-jsx.d.ts',
+          './svelte-native-jsx.d.ts'
+      ].map((f) => modules.typescript.sys.resolvePath(resolve(svelteTsPath, f)));
+      return svelteTsxFiles;*/
+      return [];
+  }
+
+  function patchCompilerOptions(project: ts.server.Project) {
+      const compilerOptions = project.getCompilerOptions();
+      // Patch needed because svelte2tsx creates jsx/tsx files
+      compilerOptions.jsx = modules.typescript.JsxEmit.Preserve;
+
+      // detect which JSX namespace to use (astro | astronative) if not specified or not compatible
+      if (!compilerOptions.jsxFactory?.startsWith('astro')) {
+          // Default to regular svelte, this causes the usage of the "astro.JSX" namespace
+          // We don't need to add a switch for astro-native because the jsx is only relevant
+          // within Astro files, which this plugin does not deal with.
+          compilerOptions.jsxFactory = 'svelte.createElement';
+      }
+  }
+
+  function isAstroProject(info: ts.server.PluginCreateInfo) {
+      // Add more checks like "no Astro file found" or "no config file found"?
+      const compilerOptions = info.project.getCompilerOptions();
+      const isNoJsxProject =
+          (!compilerOptions.jsx || compilerOptions.jsx === modules.typescript.JsxEmit.Preserve) &&
+          (!compilerOptions.jsxFactory || compilerOptions.jsxFactory.startsWith('astro')) &&
+          !compilerOptions.jsxFragmentFactory &&
+          !compilerOptions.jsxImportSource;
+      return isNoJsxProject;
+  }
+
+  return { create, getExternalFiles };
+}
+
+export = init;

--- a/packages/ts-plugin/src/index.ts
+++ b/packages/ts-plugin/src/index.ts
@@ -35,27 +35,27 @@ function init(modules: { typescript: typeof ts }) {
 
   function getExternalFiles(_project: ts.server.ConfiguredProject) {
       // Needed so the ambient definitions are known inside the tsx files
-      /*const svelteTsPath = dirname(require.resolve('svelte2tsx'));
-      const svelteTsxFiles = [
-          './svelte-shims.d.ts',
-          './svelte-jsx.d.ts',
-          './svelte-native-jsx.d.ts'
-      ].map((f) => modules.typescript.sys.resolvePath(resolve(svelteTsPath, f)));
-      return svelteTsxFiles;*/
+      /*const astroTsPath = dirname(require.resolve('astro2tsx'));
+      const astroTsxFiles = [
+          './astro-shims.d.ts',
+          './astro-jsx.d.ts',
+          './astro-native-jsx.d.ts'
+      ].map((f) => modules.typescript.sys.resolvePath(resolve(astroTsPath, f)));
+      return astroTsxFiles;*/
       return [];
   }
 
   function patchCompilerOptions(project: ts.server.Project) {
       const compilerOptions = project.getCompilerOptions();
-      // Patch needed because svelte2tsx creates jsx/tsx files
+      // Patch needed because astro2tsx creates jsx/tsx files
       compilerOptions.jsx = modules.typescript.JsxEmit.Preserve;
 
       // detect which JSX namespace to use (astro | astronative) if not specified or not compatible
       if (!compilerOptions.jsxFactory?.startsWith('astro')) {
-          // Default to regular svelte, this causes the usage of the "astro.JSX" namespace
+          // Default to regular astro, this causes the usage of the "astro.JSX" namespace
           // We don't need to add a switch for astro-native because the jsx is only relevant
           // within Astro files, which this plugin does not deal with.
-          compilerOptions.jsxFactory = 'svelte.createElement';
+          compilerOptions.jsxFactory = 'astro.createElement';
       }
   }
 

--- a/packages/ts-plugin/src/language-service/completions.ts
+++ b/packages/ts-plugin/src/language-service/completions.ts
@@ -1,0 +1,73 @@
+import type ts from 'typescript/lib/tsserverlibrary';
+import { Logger } from '../logger.js';
+import { isAstroFilePath, replaceDeep } from '../utils.js';
+
+const componentPostfix = '__AstroComponent_';
+
+export function decorateCompletions(ls: ts.LanguageService, logger: Logger): void {
+    const getCompletionsAtPosition = ls.getCompletionsAtPosition;
+    ls.getCompletionsAtPosition = (fileName, position, options) => {
+        const completions = getCompletionsAtPosition(fileName, position, options);
+        if (!completions) {
+            return completions;
+        }
+        return {
+            ...completions,
+            entries: completions.entries.map((entry) => {
+                if (
+                    !isAstroFilePath(entry.source || '') ||
+                    !entry.name.endsWith(componentPostfix)
+                ) {
+                    return entry;
+                }
+                return {
+                    ...entry,
+                    name: entry.name.slice(0, -componentPostfix.length)
+                };
+            })
+        };
+    };
+
+    const getCompletionEntryDetails = ls.getCompletionEntryDetails;
+    ls.getCompletionEntryDetails = (
+        fileName,
+        position,
+        entryName,
+        formatOptions,
+        source,
+        preferences,
+        data
+    ) => {
+        const details = getCompletionEntryDetails(
+            fileName,
+            position,
+            entryName,
+            formatOptions,
+            source,
+            preferences,
+            data
+        );
+        if (details || !isAstroFilePath(source || '')) {
+            return details;
+        }
+
+        // In the completion list we removed the component postfix. Internally,
+        // the language service saved the list with the postfix, so details
+        // won't match anything. Therefore add it back and remove it afterwards again.
+        const astroDetails = getCompletionEntryDetails(
+            fileName,
+            position,
+            entryName + componentPostfix,
+            formatOptions,
+            source,
+            preferences,
+            data
+        );
+        if (!astroDetails) {
+            return undefined;
+        }
+        logger.debug('Found Astro Component import completion details');
+
+        return replaceDeep(astroDetails, componentPostfix, '');
+    };
+}

--- a/packages/ts-plugin/src/language-service/definition.ts
+++ b/packages/ts-plugin/src/language-service/definition.ts
@@ -1,0 +1,46 @@
+import type ts from 'typescript/lib/tsserverlibrary';
+import { Logger } from '../logger';
+import { AstroSnapshotManager } from '../astro-snapshots';
+import { isNotNullOrUndefined, isAstroFilePath } from '../utils';
+
+export function decorateGetDefinition(
+    ls: ts.LanguageService,
+    snapshotManager: AstroSnapshotManager,
+    logger: Logger
+): void {
+    const getDefinitionAndBoundSpan = ls.getDefinitionAndBoundSpan;
+    ls.getDefinitionAndBoundSpan = (fileName, position) => {
+        const definition = getDefinitionAndBoundSpan(fileName, position);
+        if (!definition?.definitions) {
+            return definition;
+        }
+
+        return {
+            ...definition,
+            definitions: definition.definitions
+                .map((def) => {
+                    if (!isAstroFilePath(def.fileName)) {
+                        return def;
+                    }
+
+                    let textSpan = snapshotManager
+                        .get(def.fileName)
+                        ?.getOriginalTextSpan(def.textSpan);
+                    if (!textSpan) {
+                        // Unmapped positions are for example the default export.
+                        // Fall back to the start of the file to at least go to the correct file.
+                        textSpan = { start: 0, length: 1 };
+                    }
+                    return {
+                        ...def,
+                        textSpan,
+                        // Spare the work for now
+                        originalTextSpan: undefined,
+                        contextSpan: undefined,
+                        originalContextSpan: undefined
+                    };
+                })
+                .filter(isNotNullOrUndefined)
+        };
+    };
+}

--- a/packages/ts-plugin/src/language-service/diagnostics.ts
+++ b/packages/ts-plugin/src/language-service/diagnostics.ts
@@ -1,0 +1,45 @@
+import type ts from 'typescript/lib/tsserverlibrary';
+import { Logger } from '../logger.js';
+import { isAstroFilePath } from '../utils.js';
+
+export function decorateDiagnostics(ls: ts.LanguageService, logger: Logger): void {
+    decorateSyntacticDiagnostics(ls);
+    decorateSemanticDiagnostics(ls);
+    decorateSuggestionDiagnostics(ls);
+}
+
+function decorateSyntacticDiagnostics(ls: ts.LanguageService): void {
+    const getSyntacticDiagnostics = ls.getSyntacticDiagnostics;
+    ls.getSyntacticDiagnostics = (fileName: string) => {
+        // Diagnostics inside Astro files are done
+        // by the svelte-language-server / Svelte for VS Code extension
+        if (isAstroFilePath(fileName)) {
+            return [];
+        }
+        return getSyntacticDiagnostics(fileName);
+    };
+}
+
+function decorateSemanticDiagnostics(ls: ts.LanguageService): void {
+    const getSemanticDiagnostics = ls.getSemanticDiagnostics;
+    ls.getSemanticDiagnostics = (fileName: string) => {
+        // Diagnostics inside Astro files are done
+        // by the @astrojs/language-server / Astro for VS Code extension
+        if (isAstroFilePath(fileName)) {
+            return [];
+        }
+        return getSemanticDiagnostics(fileName);
+    };
+}
+
+function decorateSuggestionDiagnostics(ls: ts.LanguageService): void {
+    const getSuggestionDiagnostics = ls.getSuggestionDiagnostics;
+    ls.getSuggestionDiagnostics = (fileName: string) => {
+        // Diagnostics inside Svelte files are done
+        // by the @astrojs/language-server / Astro for VS Code extension
+        if (isAstroFilePath(fileName)) {
+            return [];
+        }
+        return getSuggestionDiagnostics(fileName);
+    };
+}

--- a/packages/ts-plugin/src/language-service/diagnostics.ts
+++ b/packages/ts-plugin/src/language-service/diagnostics.ts
@@ -12,7 +12,7 @@ function decorateSyntacticDiagnostics(ls: ts.LanguageService): void {
     const getSyntacticDiagnostics = ls.getSyntacticDiagnostics;
     ls.getSyntacticDiagnostics = (fileName: string) => {
         // Diagnostics inside Astro files are done
-        // by the svelte-language-server / Svelte for VS Code extension
+        // by the @astrojs/language-server / Astro for VS Code extension
         if (isAstroFilePath(fileName)) {
             return [];
         }
@@ -35,7 +35,7 @@ function decorateSemanticDiagnostics(ls: ts.LanguageService): void {
 function decorateSuggestionDiagnostics(ls: ts.LanguageService): void {
     const getSuggestionDiagnostics = ls.getSuggestionDiagnostics;
     ls.getSuggestionDiagnostics = (fileName: string) => {
-        // Diagnostics inside Svelte files are done
+        // Diagnostics inside Astro files are done
         // by the @astrojs/language-server / Astro for VS Code extension
         if (isAstroFilePath(fileName)) {
             return [];

--- a/packages/ts-plugin/src/language-service/find-references.ts
+++ b/packages/ts-plugin/src/language-service/find-references.ts
@@ -1,0 +1,95 @@
+import type ts from 'typescript/lib/tsserverlibrary';
+import { Logger } from '../logger';
+import { AstroSnapshotManager } from '../astro-snapshots.js';
+import { isNotNullOrUndefined, isAstroFilePath } from '../utils.js';
+
+export function decorateFindReferences(
+    ls: ts.LanguageService,
+    snapshotManager: AstroSnapshotManager,
+    logger: Logger
+): void {
+    decorateGetReferencesAtPosition(ls, snapshotManager, logger);
+    _decorateFindReferences(ls, snapshotManager, logger);
+}
+
+function _decorateFindReferences(
+    ls: ts.LanguageService,
+    snapshotManager: AstroSnapshotManager,
+    logger: Logger
+) {
+    const findReferences = ls.findReferences;
+    ls.findReferences = (fileName, position) => {
+        const references = findReferences(fileName, position);
+        return references
+            ?.map((reference) => {
+                const snapshot = snapshotManager.get(reference.definition.fileName);
+                if (!isAstroFilePath(reference.definition.fileName) || !snapshot) {
+                    return reference;
+                }
+
+                const textSpan = snapshot.getOriginalTextSpan(reference.definition.textSpan);
+                if (!textSpan) {
+                    return null;
+                }
+
+                return {
+                    definition: {
+                        ...reference.definition,
+                        textSpan,
+                        // Spare the work for now
+                        originalTextSpan: undefined
+                    },
+                    references: mapReferences(reference.references, snapshotManager, logger)
+                };
+            })
+            .filter(isNotNullOrUndefined);
+    };
+}
+
+function decorateGetReferencesAtPosition(
+    ls: ts.LanguageService,
+    snapshotManager: AstroSnapshotManager,
+    logger: Logger
+) {
+    const getReferencesAtPosition = ls.getReferencesAtPosition;
+    ls.getReferencesAtPosition = (fileName, position) => {
+        const references = getReferencesAtPosition(fileName, position);
+        return references && mapReferences(references, snapshotManager, logger);
+    };
+}
+
+function mapReferences(
+    references: ts.ReferenceEntry[],
+    snapshotManager: AstroSnapshotManager,
+    logger: Logger
+): ts.ReferenceEntry[] {
+    return references
+        .map((reference) => {
+            const snapshot = snapshotManager.get(reference.fileName);
+            if (!isAstroFilePath(reference.fileName) || !snapshot) {
+                return reference;
+            }
+
+            const textSpan = snapshot.getOriginalTextSpan(reference.textSpan);
+            if (!textSpan) {
+                return null;
+            }
+
+            logger.debug(
+                'Find references; map textSpan: changed',
+                reference.textSpan,
+                'to',
+                textSpan
+            );
+
+            return {
+                ...reference,
+                textSpan,
+                // Spare the work for now
+                contextSpan: undefined,
+                originalTextSpan: undefined,
+                originalContextSpan: undefined
+            };
+        })
+        .filter(isNotNullOrUndefined);
+}

--- a/packages/ts-plugin/src/language-service/implementation.ts
+++ b/packages/ts-plugin/src/language-service/implementation.ts
@@ -1,0 +1,38 @@
+import type ts from 'typescript/lib/tsserverlibrary';
+import { Logger } from '../logger.js';
+import { AstroSnapshotManager } from '../astro-snapshots.js';
+import { isNotNullOrUndefined, isAstroFilePath } from '../utils.js';
+
+export function decorateGetImplementation(
+    ls: ts.LanguageService,
+    snapshotManager: AstroSnapshotManager,
+    logger: Logger
+): void {
+    const getImplementationAtPosition = ls.getImplementationAtPosition;
+    ls.getImplementationAtPosition = (fileName, position) => {
+        const implementation = getImplementationAtPosition(fileName, position);
+        return implementation
+            ?.map((impl) => {
+                if (!isAstroFilePath(impl.fileName)) {
+                    return impl;
+                }
+
+                const textSpan = snapshotManager
+                    .get(impl.fileName)
+                    ?.getOriginalTextSpan(impl.textSpan);
+                if (!textSpan) {
+                    return undefined;
+                }
+
+                return {
+                    ...impl,
+                    textSpan,
+                    // Spare the work for now
+                    contextSpan: undefined,
+                    originalTextSpan: undefined,
+                    originalContextSpan: undefined
+                };
+            })
+            .filter(isNotNullOrUndefined);
+    };
+}

--- a/packages/ts-plugin/src/language-service/index.ts
+++ b/packages/ts-plugin/src/language-service/index.ts
@@ -1,0 +1,43 @@
+import type ts from 'typescript/lib/tsserverlibrary';
+import { Logger } from '../logger';
+import { AstroSnapshotManager } from '../astro-snapshots.js';
+import { isAstroFilePath } from '../utils.js';
+import { decorateCompletions } from './completions.js';
+import { decorateGetDefinition } from './definition.js';
+import { decorateDiagnostics } from './diagnostics.js';
+import { decorateFindReferences } from './find-references.js';
+import { decorateGetImplementation } from './implementation.js';
+import { decorateRename } from './rename.js';
+
+export function decorateLanguageService(
+    ls: ts.LanguageService,
+    snapshotManager: AstroSnapshotManager,
+    logger: Logger
+): ts.LanguageService {
+    patchLineColumnOffset(ls, snapshotManager);
+    decorateRename(ls, snapshotManager, logger);
+    decorateDiagnostics(ls, logger);
+    decorateFindReferences(ls, snapshotManager, logger);
+    decorateCompletions(ls, logger);
+    decorateGetDefinition(ls, snapshotManager, logger);
+    decorateGetImplementation(ls, snapshotManager, logger);
+    return ls;
+}
+
+function patchLineColumnOffset(ls: ts.LanguageService, snapshotManager: AstroSnapshotManager) {
+    if (!ls.toLineColumnOffset) {
+        return;
+    }
+
+    // We need to patch this because (according to source, only) getDefinition uses this
+    const toLineColumnOffset = ls.toLineColumnOffset;
+    ls.toLineColumnOffset = (fileName, position) => {
+        if (isAstroFilePath(fileName)) {
+            const snapshot = snapshotManager.get(fileName);
+            if (snapshot) {
+                return snapshot.positionAt(position);
+            }
+        }
+        return toLineColumnOffset(fileName, position);
+    };
+}

--- a/packages/ts-plugin/src/language-service/rename.ts
+++ b/packages/ts-plugin/src/language-service/rename.ts
@@ -1,0 +1,52 @@
+import type ts from 'typescript/lib/tsserverlibrary';
+import { Logger } from '../logger.js';
+import { AstroSnapshotManager } from '../astro-snapshots.js';
+import { isNotNullOrUndefined, isAstroFilePath } from '../utils.js';
+
+export function decorateRename(
+    ls: ts.LanguageService,
+    snapshotManager: AstroSnapshotManager,
+    logger: Logger
+): void {
+    const findRenameLocations = ls.findRenameLocations;
+    ls.findRenameLocations = (
+        fileName,
+        position,
+        findInStrings,
+        findInComments,
+        providePrefixAndSuffixTextForRename
+    ) => {
+        const renameLocations = findRenameLocations(
+            fileName,
+            position,
+            findInStrings,
+            findInComments,
+            providePrefixAndSuffixTextForRename
+        );
+        return renameLocations
+            ?.map((renameLocation) => {
+                const snapshot = snapshotManager.get(renameLocation.fileName);
+                if (!isAstroFilePath(renameLocation.fileName) || !snapshot) {
+                    return renameLocation;
+                }
+
+                // TODO more needed to filter invalid locations, see RenameProvider
+                const textSpan = snapshot.getOriginalTextSpan(renameLocation.textSpan);
+                if (!textSpan) {
+                    return null;
+                }
+
+                const converted = {
+                    ...renameLocation,
+                    textSpan
+                };
+                if (converted.contextSpan) {
+                    // Not important, spare the work
+                    converted.contextSpan = undefined;
+                }
+                logger.debug('Converted rename location ', converted);
+                return converted;
+            })
+            .filter(isNotNullOrUndefined);
+    };
+}

--- a/packages/ts-plugin/src/logger.ts
+++ b/packages/ts-plugin/src/logger.ts
@@ -1,0 +1,41 @@
+import type ts from 'typescript/lib/tsserverlibrary';
+
+export class Logger {
+    constructor(
+        private tsLogService: ts.server.Logger,
+        suppressNonAstroLogs = false,
+        private logDebug = false
+    ) {
+        if (suppressNonAstroLogs) {
+            const log = this.tsLogService.info.bind(this.tsLogService);
+            this.tsLogService.info = (s: string) => {
+                if (s.startsWith('-Astro Plugin-')) {
+                    log(s);
+                }
+            };
+        }
+    }
+
+    log(...args: any[]) {
+        const str = args
+            .map((arg) => {
+                if (typeof arg === 'object') {
+                    try {
+                        return JSON.stringify(arg);
+                    } catch (e) {
+                        return '[object that cannot by stringified]';
+                    }
+                }
+                return arg;
+            })
+            .join(' ');
+        this.tsLogService.info('-Astro Plugin- ' + str);
+    }
+
+    debug(...args: any[]) {
+        if (!this.logDebug) {
+            return;
+        }
+        this.log(...args);
+    }
+}

--- a/packages/ts-plugin/src/module-loader.ts
+++ b/packages/ts-plugin/src/module-loader.ts
@@ -1,0 +1,145 @@
+import type ts from 'typescript/lib/tsserverlibrary';
+import { Logger } from './logger.js';
+import { AstroSnapshotManager } from './astro-snapshots.js';
+import { createAstroSys } from './astro-sys.js';
+import { ensureRealAstroFilePath, isVirtualAstroFilePath } from './utils.js';
+
+/**
+ * Caches resolved modules.
+ */
+class ModuleResolutionCache {
+    private cache = new Map<string, ts.ResolvedModule>();
+
+    /**
+     * Tries to get a cached module.
+     */
+    get(moduleName: string, containingFile: string): ts.ResolvedModule | undefined {
+        return this.cache.get(this.getKey(moduleName, containingFile));
+    }
+
+    /**
+     * Caches resolved module, if it is not undefined.
+     */
+    set(moduleName: string, containingFile: string, resolvedModule: ts.ResolvedModule | undefined) {
+        if (!resolvedModule) {
+            return;
+        }
+        this.cache.set(this.getKey(moduleName, containingFile), resolvedModule);
+    }
+
+    /**
+     * Deletes module from cache. Call this if a file was deleted.
+     * @param resolvedModuleName full path of the module
+     */
+    delete(resolvedModuleName: string): void {
+        this.cache.forEach((val, key) => {
+            if (val.resolvedFileName === resolvedModuleName) {
+                this.cache.delete(key);
+            }
+        });
+    }
+
+    private getKey(moduleName: string, containingFile: string) {
+        return containingFile + ':::' + ensureRealAstroFilePath(moduleName);
+    }
+}
+
+/**
+ * Creates a module loader than can also resolve `.svelte` files.
+ *
+ * The typescript language service tries to look up other files that are referenced in the currently open svelte file.
+ * For `.ts`/`.js` files this works, for `.svelte` files it does not by default.
+ * Reason: The typescript language service does not know about the `.svelte` file ending,
+ * so it assumes it's a normal typescript file and searches for files like `../Component.svelte.ts`, which is wrong.
+ * In order to fix this, we need to wrap typescript's module resolution and reroute all `.svelte.ts` file lookups to .svelte.
+ */
+export function patchModuleLoader(
+    logger: Logger,
+    snapshotManager: AstroSnapshotManager,
+    typescript: typeof ts,
+    lsHost: ts.LanguageServiceHost,
+    project: ts.server.Project
+): void {
+    const astroSys = createAstroSys(logger);
+    const moduleCache = new ModuleResolutionCache();
+    const origResolveModuleNames = lsHost.resolveModuleNames?.bind(lsHost);
+
+    lsHost.resolveModuleNames = resolveModuleNames;
+
+    const origRemoveFile = project.removeFile.bind(project);
+    project.removeFile = (info, fileExists, detachFromProject) => {
+        logger.log('File is being removed. Delete from cache: ', info.fileName);
+        moduleCache.delete(info.fileName);
+        return origRemoveFile(info, fileExists, detachFromProject);
+    };
+
+    function resolveModuleNames(
+        moduleNames: string[],
+        containingFile: string,
+        reusedNames: string[] | undefined,
+        redirectedReference: ts.ResolvedProjectReference | undefined,
+        compilerOptions: ts.CompilerOptions
+    ): Array<ts.ResolvedModule | undefined> {
+        logger.log('Resolving modules names for ' + containingFile);
+        // Try resolving all module names with the original method first.
+        // The ones that are undefined will be re-checked if they are a
+        // Svelte file and if so, are resolved, too. This way we can defer
+        // all module resolving logic except for Svelte files to TypeScript.
+        const resolved =
+            origResolveModuleNames?.(
+                moduleNames,
+                containingFile,
+                reusedNames,
+                redirectedReference,
+                compilerOptions
+            ) || Array.from<undefined>(Array(moduleNames.length));
+
+        return resolved.map((moduleName, idx) => {
+            const fileName = moduleNames[idx];
+            if (moduleName || !ensureRealAstroFilePath(fileName).endsWith('.astro')) {
+                return moduleName;
+            }
+
+            const cachedModule = moduleCache.get(fileName, containingFile);
+            if (cachedModule) {
+                return cachedModule;
+            }
+
+            const resolvedModule = resolveModuleName(fileName, containingFile, compilerOptions);
+            moduleCache.set(fileName, containingFile, resolvedModule);
+            return resolvedModule;
+        });
+    }
+
+    function resolveModuleName(
+        name: string,
+        containingFile: string,
+        compilerOptions: ts.CompilerOptions
+    ): ts.ResolvedModule | undefined {
+        const astroResolvedModule = typescript.resolveModuleName(
+            name,
+            containingFile,
+            compilerOptions,
+            astroSys
+        ).resolvedModule;
+        if (
+            !astroResolvedModule ||
+            !isVirtualAstroFilePath(astroResolvedModule.resolvedFileName)
+        ) {
+            return astroResolvedModule;
+        }
+
+        const resolvedFileName = ensureRealAstroFilePath(astroResolvedModule.resolvedFileName);
+        logger.log('Resolved', name, 'to Svelte file', resolvedFileName);
+        const snapshot = snapshotManager.create(resolvedFileName);
+        if (!snapshot) {
+            return undefined;
+        }
+
+        const resolvedAstroModule: ts.ResolvedModuleFull = {
+            extension: snapshot.isTsFile ? typescript.Extension.Tsx : typescript.Extension.Jsx,
+            resolvedFileName
+        };
+        return resolvedAstroModule;
+    }
+}

--- a/packages/ts-plugin/src/module-loader.ts
+++ b/packages/ts-plugin/src/module-loader.ts
@@ -45,13 +45,13 @@ class ModuleResolutionCache {
 }
 
 /**
- * Creates a module loader than can also resolve `.svelte` files.
+ * Creates a module loader than can also resolve `.astro` files.
  *
- * The typescript language service tries to look up other files that are referenced in the currently open svelte file.
- * For `.ts`/`.js` files this works, for `.svelte` files it does not by default.
- * Reason: The typescript language service does not know about the `.svelte` file ending,
- * so it assumes it's a normal typescript file and searches for files like `../Component.svelte.ts`, which is wrong.
- * In order to fix this, we need to wrap typescript's module resolution and reroute all `.svelte.ts` file lookups to .svelte.
+ * The typescript language service tries to look up other files that are referenced in the currently open astro file.
+ * For `.ts`/`.js` files this works, for `.astro` files it does not by default.
+ * Reason: The typescript language service does not know about the `.astro` file ending,
+ * so it assumes it's a normal typescript file and searches for files like `../Component.astro.ts`, which is wrong.
+ * In order to fix this, we need to wrap typescript's module resolution and reroute all `.astro.ts` file lookups to .astro.
  */
 export function patchModuleLoader(
     logger: Logger,
@@ -83,8 +83,8 @@ export function patchModuleLoader(
         logger.log('Resolving modules names for ' + containingFile);
         // Try resolving all module names with the original method first.
         // The ones that are undefined will be re-checked if they are a
-        // Svelte file and if so, are resolved, too. This way we can defer
-        // all module resolving logic except for Svelte files to TypeScript.
+        // astro file and if so, are resolved, too. This way we can defer
+        // all module resolving logic except for astro files to TypeScript.
         const resolved =
             origResolveModuleNames?.(
                 moduleNames,
@@ -130,7 +130,7 @@ export function patchModuleLoader(
         }
 
         const resolvedFileName = ensureRealAstroFilePath(astroResolvedModule.resolvedFileName);
-        logger.log('Resolved', name, 'to Svelte file', resolvedFileName);
+        logger.log('Resolved', name, 'to astro file', resolvedFileName);
         const snapshot = snapshotManager.create(resolvedFileName);
         if (!snapshot) {
             return undefined;

--- a/packages/ts-plugin/src/source-mapper.ts
+++ b/packages/ts-plugin/src/source-mapper.ts
@@ -1,0 +1,123 @@
+import { decode } from 'sourcemap-codec';
+import type ts from 'typescript/lib/tsserverlibrary';
+
+type LineChar = ts.LineAndCharacter;
+
+export type FileMapping = LineMapping[];
+
+type LineMapping = CharacterMapping[]; // FileMapping[generated_line_index] = LineMapping
+
+type CharacterMapping = [
+    number, // generated character
+    number, // original file
+    number, // original line
+    number //  original index
+];
+
+type ReorderedChar = [
+    original_character: number,
+    generated_line: number,
+    generated_character: number
+];
+
+interface ReorderedMap {
+    [original_line: number]: ReorderedChar[];
+}
+
+function binaryInsert(array: number[], value: number): void;
+function binaryInsert<T extends Record<any, number> | number[]>(
+    array: T[],
+    value: T,
+    key: keyof T
+): void;
+function binaryInsert<A extends Array<Record<any, number>> | number[]>(
+    array: A,
+    value: A[any],
+    key?: keyof (A[any] & object)
+) {
+    if (0 === key) key = '0' as keyof A[any];
+    const index = 1 + binarySearch(array, (key ? value[key] : value) as number, key);
+    let i = array.length;
+    while (index !== i--) array[1 + i] = array[i];
+    array[index] = value;
+}
+
+function binarySearch<T extends object | number>(
+    array: T[],
+    target: number,
+    key?: keyof (T & object)
+) {
+    if (!array || 0 === array.length) return -1;
+    if (0 === key) key = '0' as keyof T;
+    let low = 0;
+    let high = array.length - 1;
+    while (low <= high) {
+        const i = low + ((high - low) >> 1);
+        const item = undefined === key ? array[i] : array[i][key];
+        if (item === target) return i;
+        if (item < target) low = i + 1;
+        else high = i - 1;
+    }
+    if ((low = ~low) < 0) low = ~low - 1;
+    return low;
+}
+
+export class SourceMapper {
+    private mappings: FileMapping;
+    private reverseMappings?: ReorderedMap;
+
+    constructor(mappings: FileMapping | string) {
+        if (typeof mappings === 'string') this.mappings = decode(mappings) as FileMapping;
+        else this.mappings = mappings;
+    }
+
+    getOriginalPosition(position: LineChar): LineChar {
+        const lineMap = this.mappings[position.line];
+        if (!lineMap) {
+            return { line: -1, character: -1 };
+        }
+
+        const closestMatch = binarySearch(lineMap, position.character, 0);
+        const match = lineMap[closestMatch];
+        if (!match) {
+            return { line: -1, character: -1 };
+        }
+
+        const { 2: line, 3: character } = match;
+        return { line, character };
+    }
+
+    getGeneratedPosition(position: LineChar): LineChar {
+        if (!this.reverseMappings) this.computeReversed();
+        const lineMap = this.reverseMappings![position.line];
+        if (!lineMap) {
+            return { line: -1, character: -1 };
+        }
+
+        const closestMatch = binarySearch(lineMap, position.character, 0);
+        const match = lineMap[closestMatch];
+        if (!match) {
+            return { line: -1, character: -1 };
+        }
+
+        const { 1: line, 2: character } = match;
+        return { line, character };
+    }
+
+    private computeReversed() {
+        this.reverseMappings = {} as ReorderedMap;
+        for (let generated_line = 0; generated_line !== this.mappings.length; generated_line++) {
+            for (const { 0: generated_index, 2: original_line, 3: original_character_index } of this
+                .mappings[generated_line]) {
+                const reordered_char: ReorderedChar = [
+                    original_character_index,
+                    generated_line,
+                    generated_index
+                ];
+                if (original_line in this.reverseMappings)
+                    binaryInsert(this.reverseMappings[original_line], reordered_char, 0);
+                else this.reverseMappings[original_line] = [reordered_char];
+            }
+        }
+    }
+}

--- a/packages/ts-plugin/src/utils.ts
+++ b/packages/ts-plugin/src/utils.ts
@@ -1,0 +1,66 @@
+export function isAstroFilePath(filePath: string) {
+  return filePath.endsWith('.astro');
+}
+
+export function isVirtualAstroFilePath(filePath: string) {
+  return filePath.endsWith('.astro.ts');
+}
+
+export function toRealAstroFilePath(filePath: string) {
+  return filePath.slice(0, -'.ts'.length);
+}
+
+export function ensureRealAstroFilePath(filePath: string) {
+  return isVirtualAstroFilePath(filePath) ? toRealAstroFilePath(filePath) : filePath;
+}
+
+export function isNotNullOrUndefined<T>(val: T | undefined | null): val is T {
+  return val !== undefined && val !== null;
+}
+
+/**
+* Checks if this a section that should be completely ignored
+* because it's purely generated.
+*/
+export function isInGeneratedCode(text: string, start: number, end: number) {
+  const lineStart = text.lastIndexOf('\n', start);
+  const lineEnd = text.indexOf('\n', end);
+  const lastStart = text.substring(lineStart, start).lastIndexOf('/*Ωignore_startΩ*/');
+  const lastEnd = text.substring(lineStart, start).lastIndexOf('/*Ωignore_endΩ*/');
+  return lastStart > lastEnd && text.substring(end, lineEnd).includes('/*Ωignore_endΩ*/');
+}
+
+/**
+* Checks that this isn't a text span that should be completely ignored
+* because it's purely generated.
+*/
+export function isNoTextSpanInGeneratedCode(text: string, span: ts.TextSpan) {
+  return !isInGeneratedCode(text, span.start, span.start + span.length);
+}
+
+/**
+* Replace all occurrences of a string within an object with another string,
+*/
+export function replaceDeep<T extends Record<string, any>>(
+  obj: T,
+  searchStr: string | RegExp,
+  replacementStr: string
+): T {
+  return _replaceDeep(obj);
+
+  function _replaceDeep(_obj: any): any {
+      if (typeof _obj === 'string') {
+          return _obj.replace(searchStr, replacementStr);
+      }
+      if (Array.isArray(_obj)) {
+          return _obj.map((entry) => _replaceDeep(entry));
+      }
+      if (typeof _obj === 'object') {
+          return Object.keys(_obj).reduce((_o, key) => {
+              _o[key] = _replaceDeep(_obj[key]);
+              return _o;
+          }, {} as any);
+      }
+      return _obj;
+  }
+}

--- a/packages/ts-plugin/tsconfig.json
+++ b/packages/ts-plugin/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src",
+    "target": "ES2020",
+    "module": "CommonJS"
+  },
+  "include": ["src"],
+  "exclude": ["node_modules"]
+}

--- a/packages/vscode/package.json
+++ b/packages/vscode/package.json
@@ -27,6 +27,7 @@
   ],
   "dependencies": {
     "@astrojs/language-server": "0.6.0",
+    "@astrojs/ts-plugin": "0.1.0",
     "vscode-emmet-helper": "2.1.2",
     "vscode-html-languageservice": "^3.0.3",
     "vscode-languageclient": "~7.0.0"
@@ -48,6 +49,12 @@
     "url": "https://github.com/snowpackjs/astro"
   },
   "contributes": {
+    "typescriptServerPlugins": [
+      {
+          "name": "@astrojs/ts-plugin",
+          "enableForWorkspaceTypeScriptVersions": true
+      }
+    ],
     "configuration": {
       "type": "object",
       "title": "Astro configuration",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1623,6 +1623,16 @@
   resolved "https://registry.yarnpkg.com/@tootallnate/once/-/once-1.1.2.tgz#ccb91445360179a04e7fe6aff78c00ffc1eeaf82"
   integrity sha512-RbzJvlNzmRq5c3O09UipeuXno4tA1FE6ikOjxZK0tuxVv3412l64l5t1W5pj4+rJq9vpkm/kwiR07aZXnsKPxw==
 
+"@ts-morph/common@~0.11.0":
+  version "0.11.0"
+  resolved "https://registry.yarnpkg.com/@ts-morph/common/-/common-0.11.0.tgz#df94af35f42d01d9d389bfdefc8bcc3f6a59a192"
+  integrity sha512-Ti2tpROSVHlBoNiJKVUYPNk/yCPb1Bcly4RsSwC2F9a8PMMYfEYovRcghTu6N5o66Jq0yvPXN3uNaO4a3zskTA==
+  dependencies:
+    fast-glob "^3.2.7"
+    minimatch "^3.0.4"
+    mkdirp "^1.0.4"
+    path-browserify "^1.0.1"
+
 "@tsconfig/node12@^1.0.0":
   version "1.0.9"
   resolved "https://registry.yarnpkg.com/@tsconfig/node12/-/node12-1.0.9.tgz#62c1f6dee2ebd9aead80dc3afa56810e58e1a04c"
@@ -2729,6 +2739,11 @@ cmd-shim@^4.0.1, cmd-shim@^4.1.0:
   dependencies:
     mkdirp-infer-owner "^2.0.0"
 
+code-block-writer@^10.1.1:
+  version "10.1.1"
+  resolved "https://registry.yarnpkg.com/code-block-writer/-/code-block-writer-10.1.1.tgz#ad5684ed4bfb2b0783c8b131281ae84ee640a42f"
+  integrity sha512-67ueh2IRGst/51p0n6FvPrnRjAGHY5F8xdjkgrYE7DDzpJe6qA07RYQ9VcoUeo5ATOjSOiWpSL3SWBRRbempMw==
+
 code-point-at@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/code-point-at/-/code-point-at-1.1.0.tgz#0d070b4d043a5bea33a2f1a40e2edb3d9a4ccf77"
@@ -3730,7 +3745,7 @@ fast-equals@^2.0.1:
   resolved "https://registry.yarnpkg.com/fast-equals/-/fast-equals-2.0.3.tgz#7039b0a039909f345a2ce53f6202a14e5f392efc"
   integrity sha512-0EMw4TTUxsMDpDkCg0rXor2gsg+npVrMIHbEhvD0HZyIhUX6AktC/yasm+qKwfyswd06Qy95ZKk8p2crTo0iPA==
 
-fast-glob@^3.1.1:
+fast-glob@^3.1.1, fast-glob@^3.2.7:
   version "3.2.7"
   resolved "https://registry.yarnpkg.com/fast-glob/-/fast-glob-3.2.7.tgz#fd6cb7a2d7e9aa7a7846111e85a196d6b2f766a1"
   integrity sha512-rYGMRwip6lUMvYD3BTScMwT1HtAs2d71SMv66Vrxs0IekGZEjhM0pcMfjQPnknBt2zeCwQMEupiN02ZP4DiT1Q==
@@ -6550,6 +6565,11 @@ pascal-case@^3.1.2:
     no-case "^3.0.4"
     tslib "^2.0.3"
 
+path-browserify@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/path-browserify/-/path-browserify-1.0.1.tgz#d98454a9c3753d5790860f16f68867b9e46be1fd"
+  integrity sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g==
+
 path-exists@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/path-exists/-/path-exists-3.0.0.tgz#ce0ebeaa5f78cb18925ea7d810d7b59b010fd515"
@@ -8180,6 +8200,14 @@ trough@^1.0.0:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/trough/-/trough-1.0.5.tgz#b8b639cefad7d0bb2abd37d433ff8293efa5f406"
   integrity sha512-rvuRbTarPXmMb79SmzEp8aqXNKcK+y0XaB298IXueQ8I2PsrATcPBCSPyK/dDNa2iWOhKlfNnOjdAOTBU/nkFA==
+
+ts-morph@^12.0.0:
+  version "12.0.0"
+  resolved "https://registry.yarnpkg.com/ts-morph/-/ts-morph-12.0.0.tgz#a601c3538703755cbfa2d42b62c52df73e9dbbd7"
+  integrity sha512-VHC8XgU2fFW7yO1f/b3mxKDje1vmyzFXHWzOYmKEkCEwcLjDtbdLgBQviqj4ZwP4MJkQtRo6Ha2I29lq/B+VxA==
+  dependencies:
+    "@ts-morph/common" "~0.11.0"
+    code-block-writer "^10.1.1"
 
 tslib@^1.8.1, tslib@^1.9.0:
   version "1.14.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1623,6 +1623,11 @@
   resolved "https://registry.yarnpkg.com/@tootallnate/once/-/once-1.1.2.tgz#ccb91445360179a04e7fe6aff78c00ffc1eeaf82"
   integrity sha512-RbzJvlNzmRq5c3O09UipeuXno4tA1FE6ikOjxZK0tuxVv3412l64l5t1W5pj4+rJq9vpkm/kwiR07aZXnsKPxw==
 
+"@tsconfig/node12@^1.0.0":
+  version "1.0.9"
+  resolved "https://registry.yarnpkg.com/@tsconfig/node12/-/node12-1.0.9.tgz#62c1f6dee2ebd9aead80dc3afa56810e58e1a04c"
+  integrity sha512-/yBMcem+fbvhSREH+s14YJi18sp7J9jpuhYByADT2rypfajMZZN4WQ6zBGgBKp53NKmqI36wFYDb3yaMPurITw==
+
 "@types/acorn@^4.0.0":
   version "4.0.6"
   resolved "https://registry.yarnpkg.com/@types/acorn/-/acorn-4.0.6.tgz#d61ca5480300ac41a7d973dd5b84d0a591154a22"
@@ -1712,6 +1717,11 @@
   version "12.20.19"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-12.20.19.tgz#538e61fc220f77ae4a4663c3d8c3cb391365c209"
   integrity sha512-niAuZrwrjKck4+XhoCw6AAVQBENHftpXw9F4ryk66fTgYaKQ53R4FI7c9vUGGw5vQis1HKBHDR1gcYI/Bq1xvw==
+
+"@types/node@^13.9.0":
+  version "13.13.52"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-13.13.52.tgz#03c13be70b9031baaed79481c0c0cfb0045e53f7"
+  integrity sha512-s3nugnZumCC//n4moGGe6tkNMyYEdaDBitVjwPxXmR5lnMG5dHePinH2EdxkG3Rh1ghFHHixAG4NJhpJW1rthQ==
 
 "@types/normalize-package-data@^2.4.0":
   version "2.4.1"
@@ -7685,7 +7695,7 @@ source-map@^0.7.3, source-map@~0.7.2:
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.7.3.tgz#5302f8169031735226544092e64981f751750383"
   integrity sha512-CkCj6giN3S+n9qrYiBTX5gystlENnRW5jZeNLHpe6aue+SrHcG5VYwujhW9s4dY31mEGsxBDrHR6oI69fTXsaQ==
 
-sourcemap-codec@^1.4.4:
+sourcemap-codec@^1.4.4, sourcemap-codec@^1.4.8:
   version "1.4.8"
   resolved "https://registry.yarnpkg.com/sourcemap-codec/-/sourcemap-codec-1.4.8.tgz#ea804bd94857402e6992d05a38ef1ae35a9ab4c4"
   integrity sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA==
@@ -8265,6 +8275,11 @@ typedarray@^0.0.6:
   version "0.0.6"
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
+
+typescript@*:
+  version "4.4.2"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.4.2.tgz#6d618640d430e3569a1dfb44f7d7e600ced3ee86"
+  integrity sha512-gzP+t5W4hdy4c+68bfcv0t400HVJMMd2+H9B7gae1nQlBzCqvrXX+6GL/b3GAgyTH966pzrZ70/fRjwAtZksSQ==
 
 typescript@^4.2.4, typescript@^4.3.1-rc:
   version "4.3.5"


### PR DESCRIPTION
## Changes

This adds a new package, `@astrojs/ts-plugin` which is a TypeScript plugin. It runs whenever a ts/tsx/js/jsx file is open in VSCode and provides type information for .astro files, allowing prop completion from .astro files.

Loom:

https://www.loom.com/share/68ec7de42cee4fc1b20083012a2c2c57

Closes #21
