### PR TITLE
Improve perf for all operations

### DIFF
--- a/.changeset/thirty-phones-matter.md
+++ b/.changeset/thirty-phones-matter.md
@@ -1,0 +1,7 @@
+---
+"@astrojs/language-server": patch
+---
+
+Improves completion performance
+
+Completion performance is improved by fixing a bug where we were giving the TypeScript compiler API the wrong name of files, causing it to search for files for a long time.

--- a/packages/language-server/src/index.ts
+++ b/packages/language-server/src/index.ts
@@ -102,7 +102,10 @@ export function startServer() {
   });
 
   // Features
-  connection.onCompletion((evt) => pluginHost.getCompletions(evt.textDocument, evt.position, evt.context));
+  connection.onCompletion(async (evt) => {
+    const promise = pluginHost.getCompletions(evt.textDocument, evt.position, evt.context);
+    return promise;
+  });
   connection.onCompletionResolve((completionItem) => {
     const data = (completionItem as AppCompletionItem).data as TextDocumentIdentifier;
 

--- a/packages/language-server/src/plugins/astro/AstroPlugin.ts
+++ b/packages/language-server/src/plugins/astro/AstroPlugin.ts
@@ -185,7 +185,7 @@ export class AstroPlugin implements CompletionsProvider, FoldingRangeProvider {
       return [];
     }
 
-    // If inside of attributes, skip.
+    // If inside of attribute value, skip.
     if (completionContext && completionContext.triggerKind === CompletionTriggerKind.TriggerCharacter && completionContext.triggerCharacter === '"') {
       return [];
     }

--- a/packages/language-server/src/plugins/typescript/languageService.ts
+++ b/packages/language-server/src/plugins/typescript/languageService.ts
@@ -99,10 +99,13 @@ async function createLanguageService(tsconfigPath: string, workspaceRoot: string
     getCurrentDirectory: () => workspaceRoot,
     getDefaultLibFileName: () => ts.getDefaultLibFilePath(project.options),
 
-    getProjectVersion: () => `${projectVersion}`,
+    getProjectVersion: () => projectVersion.toString(),
     getScriptFileNames: () => Array.from(new Set([...snapshotManager.getFileNames(), ...snapshotManager.getProjectFileNames()])),
     getScriptSnapshot,
-    getScriptVersion: (fileName: string) => getScriptSnapshot(fileName).version.toString(),
+    getScriptVersion: (fileName: string) => {
+      let snapshotVersion = getScriptSnapshot(fileName).version.toString();
+      return snapshotVersion;
+    },
   };
 
   const languageService: ts.LanguageService = ts.createLanguageService(host);

--- a/packages/language-server/src/plugins/typescript/utils.ts
+++ b/packages/language-server/src/plugins/typescript/utils.ts
@@ -178,10 +178,13 @@ export function isVirtualFilePath(filePath: string) {
 }
 
 export function toVirtualAstroFilePath(filePath: string) {
-  if (isVirtualFrameworkFilePath('astro', filePath)) {
+  if (isVirtualAstroFilePath(filePath)) {
+    return filePath;
+  } else if(isAstroFilePath(filePath)) {
+    return `${filePath}.ts`;
+  } else {
     return filePath;
   }
-  return `${filePath}.ts`;
 }
 
 export function toRealAstroFilePath(filePath: string) {


### PR DESCRIPTION
## Changes

- TypeScript internally calls us to a "sys" module that we own to search for files. We were telling it that any non-astro file needed to have a .ts extension appended. So it would keep searching for files, appending .ts many times, until ultimately giving up, but this took 300+ms.
- This fixes it by only appending the .ts for our virtual astro ts modules.
- This brings the onCompletion time down to 1-30ms.

Closes #31 

## Testing

N/A

## Docs

N/A