### PR TITLE
Provide different highlighting for component names

### DIFF
--- a/.changeset/real-parrots-ring.md
+++ b/.changeset/real-parrots-ring.md
@@ -1,0 +1,5 @@
+---
+"astro-vscode": patch
+---
+
+Provides special highlighting for component names

--- a/packages/vscode/syntaxes/astro.tmLanguage.json
+++ b/packages/vscode/syntaxes/astro.tmLanguage.json
@@ -477,7 +477,7 @@
           "name": "punctuation.definition.tag.begin.html"
         },
         "2": {
-          "name": "entity.name.tag.component.astro"
+          "name": "support.class.component.astro"
         },
         "3": {
           "name": "keyword.control.loading.astro"


### PR DESCRIPTION
## Changes

- Gives component names a slightly different highlighting style, mirroring what Svelte does
- Closes #4

<img width="422" alt="Example of new component highlighting" src="https://user-images.githubusercontent.com/361671/132763224-11eb7ed9-25d7-410e-ba1e-686a358b150b.png">
