### PR TITLE
Fix highlighting of component tag when they have an end tag

### DIFF
--- a/packages/vscode/syntaxes/astro.tmLanguage.json
+++ b/packages/vscode/syntaxes/astro.tmLanguage.json
@@ -14,7 +14,7 @@
       "include": "#astro-expressions"
     },
     {
-      "begin": "(<)([a-zA-Z0-9:-]++)(?=[^>]*></\\2>)",
+      "begin": "(<)([a-z0-9:-]++)(?=[^>]*></\\2>)",
       "beginCaptures": {
         "1": {
           "name": "punctuation.definition.tag.begin.html"
@@ -471,7 +471,7 @@
       ]
     },
     {
-      "begin": "(</?)([A-Z][a-zA-Z0-9-\\.]*|[a-z]+\\.[a-zA-Z0-9-]+)(\\:(load|idle|visible))?",
+      "begin": "(</?)([A-Z][a-zA-Z0-9-\\.]*|[a-z]+\\.[a-zA-Z0-9-]+)",
       "beginCaptures": {
         "1": {
           "name": "punctuation.definition.tag.begin.html"


### PR DESCRIPTION
## Changes

- This fixes component tag name usage when there is an end tag, so that highlighting matches the self-closing case.
