### PR TITLE
Fixes case of using blockquotes within Markdown component

### DIFF
--- a/.changeset/fluffy-lamps-drum.md
+++ b/.changeset/fluffy-lamps-drum.md
@@ -1,0 +1,5 @@
+---
+"@astrojs/language-server": patch
+---
+
+Fixes false-positive error when using blockquotes within Markdown component


### PR DESCRIPTION
## Changes

- Fixes #41 
- Using blockquote like `> quote here` within the `<Markdown>` component now ignores the TS provided error about the `>` be unrecognized.

## Testing

Manually, see below screenshot:

<img width="1681" alt="Screen Shot 2021-09-10 at 9 26 29 AM" src="https://user-images.githubusercontent.com/361671/132860910-5d7f1679-e292-4df7-a588-c85de647f8cd.png">


## Docs

N/A