### PR TITLE
Bump language server

### DIFF
--- a/.changeset/pretty-paws-sip.md
+++ b/.changeset/pretty-paws-sip.md
@@ -1,0 +1,5 @@
+---
+"@astrojs/language-server": patch
+---
+
+Bump version to fix unpublished version in npm


### PR DESCRIPTION
npm is having issues and not showing recent version of packages. Status page shows the problem: https://status.npmjs.org/

Says its fixed for new publishing, so bumping.