### PR TITLE
Prevent template errors when semicolons not used

### DIFF
--- a/.changeset/gorgeous-socks-greet.md
+++ b/.changeset/gorgeous-socks-greet.md
@@ -1,0 +1,5 @@
+---
+"@astrojs/language-server": patch
+---
+
+Fixes diagnostic issues with omitting semicolons in the frontmatter section

--- a/packages/language-server/src/plugins/typescript/astro2tsx.ts
+++ b/packages/language-server/src/plugins/typescript/astro2tsx.ts
@@ -29,6 +29,10 @@ export default function(content: string): Astro2TSXResult {
 
   // Replace frontmatter marks with comments
   let raw = content
+    // Handle case where semicolons is not used in the frontmatter section
+    .replace(/((?!^)(?<!;)\n)(---)/g, (_whole, start, _dashes) => {
+      return start + ';' + '//';
+    })
     .replace(/---/g, '///')
     // Turn comments into JS comments
     .replace(/<\s*!--([^>]*)(.*?)-->/gs, (whole) => {

--- a/packages/vscode/readme.md
+++ b/packages/vscode/readme.md
@@ -1,0 +1,7 @@
+# Astro VSCode extension
+
+This extension provides language support for `.astro` files.
+
+## Settings
+
+You can disable most features in the extension by going to your workspace settings page. Under __Extension__ find Astro configuration and uncheck the feature you do not want. For example to disable error messages unselect __TypeScript > Diagnostics: Enable__.


### PR DESCRIPTION
## Changes

- Fixes #58
- Improves the Astro -> TSX translator so that we automatically insert a semi, which is needed before JSX is understood.
