### PR TITLE
Make Astro.fetchContent default to any

### DIFF
--- a/.changeset/healthy-moons-compare.md
+++ b/.changeset/healthy-moons-compare.md
@@ -1,0 +1,5 @@
+---
+"@astrojs/language-server": patch
+---
+
+Default Astro.fetchContent to treat type param as any

--- a/packages/language-server/astro.d.ts
+++ b/packages/language-server/astro.d.ts
@@ -12,14 +12,16 @@ declare global {
 
 type AstroRenderedHTML = string;
 
-type FetchContentResult<ContentFrontmatter extends Record<string, any> = Record<string, any>> = {
+type FetchContentResultBase = {
   astro: {
     headers: string[];
     source: string;
     html: AstroRenderedHTML;
   };
   url: URL;
-} & ContentFrontmatter;
+};
+
+type FetchContentResult<T> = FetchContentResultBase & T;
 
 export type Params = Record<string, string | undefined>;
 
@@ -38,7 +40,7 @@ interface AstroBuiltinProps {
 
 interface Astro {
   isPage: boolean;
-  fetchContent<ContentFrontmatter>(globStr: string): FetchContentResult<ContentFrontmatter>[];
+  fetchContent<T = any>(globStr: string): FetchContentResult<T>[];
   props: Record<string, number | string | any>;
   request: AstroPageRequest;
   resolve: (path: string) => string;


### PR DESCRIPTION
## Changes

- Fixes #61 
- Makes `Astro.fetchContent('/path')` default to `any`. Previously it would default to `unknown` meaning if you tried to access any properties you'd get type errors. We want to opt-in to strong typing here, so it's only strong typed if you provide a type param.
