### PR TITLE
Default to allowing any key on component props

### DIFF
--- a/.changeset/silver-sheep-mix.md
+++ b/.changeset/silver-sheep-mix.md
@@ -1,0 +1,5 @@
+---
+"@astrojs/language-server": patch
+---
+
+When no Props interface is provide, treat as any

--- a/packages/language-server/src/plugins/typescript/astro2tsx.ts
+++ b/packages/language-server/src/plugins/typescript/astro2tsx.ts
@@ -5,7 +5,7 @@ const ASTRO_DEFINITION_BYTES = readFileSync(require.resolve('../../../astro.d.ts
 const ASTRO_DEFINITION_STR = ASTRO_DEFINITION_BYTES.toString('utf-8');
 
 function addProps(content: string, dtsContent: string): string {
-  let defaultExportType = 'AstroBuiltinProps';
+  let defaultExportType = 'AstroBuiltinProps & Record<string, any>';
   // Using TypeScript to parse here would cause a double-parse, slowing down the extension
   // This needs to be done a different way when the new compiler is added.
   if(/(interface|type) Props/.test(content)) {


### PR DESCRIPTION
## Changes

- Makes it so that if you don't provide a Props interface export, it defaults to `any` on the usage side.
