### PR TITLE
Prevent greedy comment translation

### DIFF
--- a/.changeset/heavy-rockets-remember.md
+++ b/.changeset/heavy-rockets-remember.md
@@ -1,0 +1,5 @@
+---
+"@astrojs/language-server": patch
+---
+
+Prevents false-positive errors when lots of comments are used

--- a/packages/language-server/src/plugins/typescript/astro2tsx.ts
+++ b/packages/language-server/src/plugins/typescript/astro2tsx.ts
@@ -35,7 +35,7 @@ export default function(content: string): Astro2TSXResult {
     })
     .replace(/---/g, '///')
     // Turn comments into JS comments
-    .replace(/<\s*!--([^>]*)(.*?)-->/gs, (whole) => {
+    .replace(/<\s*!--([^>]*)(.*?)-->/g, (whole) => {
       return `{/*${whole}*/}`;
     })
     // Turn styles into internal strings


### PR DESCRIPTION
## Changes

- When translating to tsx and converting comments, a regex was greedy causing it to capture multiple comments rather than just the one. This fixes that.
