### PR TITLE
Fix comment surrounding html

### DIFF
--- a/.changeset/slow-dodos-flow.md
+++ b/.changeset/slow-dodos-flow.md
@@ -1,0 +1,5 @@
+---
+"@astrojs/language-server": patch
+---
+
+Fixes diagnostic false-positives with comments wrapping HTML

--- a/packages/language-server/src/plugins/typescript/astro2tsx.ts
+++ b/packages/language-server/src/plugins/typescript/astro2tsx.ts
@@ -35,7 +35,7 @@ export default function(content: string): Astro2TSXResult {
     })
     .replace(/---/g, '///')
     // Turn comments into JS comments
-    .replace(/<\s*!--([^>]*)(.*?)-->/g, (whole) => {
+    .replace(/<\s*!--([^-->]*)(.*?)-->/gs, (whole) => {
       return `{/*${whole}*/}`;
     })
     // Turn styles into internal strings


### PR DESCRIPTION
## Changes

- Comments that surround HTML are converted by the tsx converter, preventing errors from displaying.
