### PR TITLE
Prevent tsconfig include from interfering with diagnostics

### DIFF
--- a/.changeset/big-oranges-perform.md
+++ b/.changeset/big-oranges-perform.md
@@ -1,0 +1,7 @@
+---
+"@astrojs/language-server": patch
+---
+
+Fixes errors when using a tsconfig.json
+
+Previously when using a tsconfig.json that had an `include` property, that property would cause diagnostics in astro files to show JSX related errors. This fixes that issue.

--- a/packages/language-server/src/plugins/typescript/languageService.ts
+++ b/packages/language-server/src/plugins/typescript/languageService.ts
@@ -65,6 +65,9 @@ async function createLanguageService(tsconfigPath: string, workspaceRoot: string
     );
   }
 
+  // Delete include so that astro files don't get excluded.
+  delete configJson.include;
+
   const existingCompilerOptions: ts.CompilerOptions = {
     jsx: ts.JsxEmit.ReactJSX,
     module: ts.ModuleKind.ESNext,


### PR DESCRIPTION
## Changes

- tsconfig.json's `include` is removed before the TypeScript language server is started up. This config is intended by the user to be used with `tsc`, in this case we want all `.astro` files to be treated as TypeScript.