### PR TITLE
Prevent react types from altering typescript diagnostics

### DIFF
--- a/.changeset/afraid-bananas-march.md
+++ b/.changeset/afraid-bananas-march.md
@@ -1,0 +1,5 @@
+---
+"@astrojs/language-server": patch
+---
+
+Prevents presence of @types/react from causing false-positive astro errors

--- a/packages/language-server/src/plugins/typescript/astro-sys.ts
+++ b/packages/language-server/src/plugins/typescript/astro-sys.ts
@@ -2,6 +2,11 @@ import * as ts from 'typescript';
 import { DocumentSnapshot } from './DocumentSnapshot';
 import { ensureRealAstroFilePath, isAstroFilePath, isVirtualAstroFilePath, toRealAstroFilePath } from './utils';
 
+const ignoredDirectories = [
+  "node_modules/@types/react"
+];
+const ignoredDirectoriesExp = new RegExp("(" + ignoredDirectories.map(n => n + "$").join("|") + ")");
+
 /**
  * This should only be accessed by TS Astro module resolution.
  */
@@ -11,6 +16,12 @@ export function createAstroSys(getSnapshot: (fileName: string) => DocumentSnapsh
     fileExists(path: string) {
       let doesExist = ts.sys.fileExists(ensureRealAstroFilePath(path));
       return doesExist;
+    },
+    directoryExists(path: string) {
+      if(ignoredDirectoriesExp.test(path)) {
+        return false;
+      }
+      return ts.sys.directoryExists(path);
     },
     readFile(path: string) {
       if (isAstroFilePath(path) || isVirtualAstroFilePath(path)) {

--- a/packages/language-server/src/plugins/typescript/languageService.ts
+++ b/packages/language-server/src/plugins/typescript/languageService.ts
@@ -69,7 +69,7 @@ async function createLanguageService(tsconfigPath: string, workspaceRoot: string
   delete configJson.include;
 
   const existingCompilerOptions: ts.CompilerOptions = {
-    jsx: ts.JsxEmit.ReactJSX,
+    jsx: ts.JsxEmit.Preserve,
     module: ts.ModuleKind.ESNext,
     target: ts.ScriptTarget.ESNext
   };


### PR DESCRIPTION
## Changes

- This prevents the present of `@types/react` from interfering with how diagnostics are applied to .astro files.
- This means if you have `@types/react` installed (for jsx/tsx files) it doesn't get applied to .astro diagnostics.