### PR TITLE
Basic rename implementation

### DIFF
--- a/.changeset/unlucky-bottles-learn.md
+++ b/.changeset/unlucky-bottles-learn.md
@@ -1,0 +1,5 @@
+---
+"@astrojs/language-server": patch
+---
+
+Added Rename Symbol capability

--- a/packages/language-server/src/plugins/PluginHost.ts
+++ b/packages/language-server/src/plugins/PluginHost.ts
@@ -9,6 +9,7 @@ import type {
   SignatureHelp,
   SignatureHelpContext,
   TextDocumentIdentifier,
+  WorkspaceEdit
 } from 'vscode-languageserver';
 import type { DocumentManager } from '../core/documents';
 import type * as d from './interfaces';
@@ -125,6 +126,16 @@ export class PluginHost {
     } else {
       return definitions.map((def) => <Location>{ range: def.targetSelectionRange, uri: def.targetUri });
     }
+  }
+
+  async rename(textDocument: TextDocumentIdentifier, position: Position, newName: string): Promise<WorkspaceEdit | null> {
+    const document = this.getDocument(textDocument.uri);
+    if (!document) {
+      throw new Error('Cannot call methods on an unopened document');
+    }
+
+    return this.execute<any>('rename', [document, position, newName], ExecuteMode.FirstNonNull);
+
   }
 
   async getSignatureHelp(

--- a/packages/language-server/src/server.ts
+++ b/packages/language-server/src/server.ts
@@ -45,6 +45,7 @@ export function startServer() {
         textDocumentSync: TextDocumentSyncKind.Incremental,
         foldingRangeProvider: true,
         definitionProvider: true,
+        renameProvider: true,
         completionProvider: {
           resolveProvider: true,
           triggerCharacters: [
@@ -145,6 +146,7 @@ export function startServer() {
   connection.onFoldingRanges((evt) => pluginHost.getFoldingRanges(evt.textDocument));
   connection.onRequest(TagCloseRequest, (evt: any) => pluginHost.doTagComplete(evt.textDocument, evt.position));
   connection.onSignatureHelp((evt, cancellationToken) => pluginHost.getSignatureHelp(evt.textDocument, evt.position, evt.context, cancellationToken));
+  connection.onRenameRequest(evt => pluginHost.rename(evt.textDocument, evt.position, evt.newName));
 
   docManager.on(
       'documentChange',


### PR DESCRIPTION
## Changes

This adds the **Rename Symbol** capability to `.astro` files.

## Testing

This is only tested manually.

## Docs

https://code.visualstudio.com/docs/editor/refactoring#_rename-symbol 😄