### PR TITLE
Add DiagnosticSeverity export

### DIFF
--- a/packages/language-server/package.json
+++ b/packages/language-server/package.json
@@ -29,12 +29,13 @@
     "vscode-emmet-helper": "2.1.2",
     "vscode-html-languageservice": "^3.0.3",
     "vscode-languageserver": "6.1.1",
+    "vscode-languageserver-protocol": "^3.16.0",
     "vscode-languageserver-textdocument": "^1.0.1"
   },
   "devDependencies": {
+    "@types/lodash": "^4.14.116",
     "astro": "0.19.1",
     "astro-scripts": "0.0.1",
-    "@types/lodash": "^4.14.116",
     "tap": "^15.0.9"
   }
 }

--- a/packages/language-server/src/check.ts
+++ b/packages/language-server/src/check.ts
@@ -2,6 +2,7 @@ import type { Diagnostic } from 'vscode-languageserver';
 import { DocumentManager } from './core/documents';
 import { ConfigManager } from './core/config';
 import { PluginHost, TypeScriptPlugin } from './plugins';
+export { DiagnosticSeverity } from 'vscode-languageserver-protocol';
 
 interface GetDiagnosticsResult {
   filePath: string;

--- a/packages/language-server/src/index.ts
+++ b/packages/language-server/src/index.ts
@@ -1,2 +1,2 @@
-export { AstroCheck } from './check';
+export { AstroCheck, DiagnosticSeverity } from './check';
 export { startServer } from './server';


### PR DESCRIPTION


## Changes

- This adds the DiagnosticSeverity as an export, as this is needed in
`astro check`.
