### PR TITLE
Rename JSX attribute to HTML attribute on Hover

### DIFF
--- a/.changeset/chilly-oranges-return.md
+++ b/.changeset/chilly-oranges-return.md
@@ -1,0 +1,5 @@
+---
+"@astrojs/language-server": patch
+---
+
+Change hover text to display HTML attribute instead of JSX

--- a/packages/language-server/src/plugins/typescript/features/HoverProvider.ts
+++ b/packages/language-server/src/plugins/typescript/features/HoverProvider.ts
@@ -6,6 +6,8 @@ import { HoverProvider } from '../../interfaces';
 import { getMarkdownDocumentation } from '../previewer';
 import { convertRange, toVirtualAstroFilePath } from '../utils';
 
+const partsMap = new Map([['JSX attribute', 'HTML attribute']]);
+
 export class HoverProviderImpl implements HoverProvider {
   constructor(private readonly lang: LanguageServiceManager) {}
 
@@ -22,7 +24,11 @@ export class HoverProviderImpl implements HoverProvider {
 
     const textSpan = info.textSpan;
 
-    const declaration = ts.displayPartsToString(info.displayParts);
+    const displayParts: ts.SymbolDisplayPart[] = (info.displayParts||[]).map(value => ({
+      text: partsMap.has(value.text) ? partsMap.get(value.text)! : value.text,
+      kind: value.kind
+    }));
+    const declaration = ts.displayPartsToString(displayParts);
     const documentation = getMarkdownDocumentation(info.documentation, info.tags);
 
     // https://microsoft.github.io/language-server-protocol/specification#textDocument_hover


### PR DESCRIPTION
## Changes

- Starting to remove all "JSX" references, this removes "JSX attribute" on hover.

<img width="498" alt="Screen Shot 2021-09-29 at 8 53 59 AM" src="https://user-images.githubusercontent.com/361671/135272324-67705d6e-d2ca-4467-acca-3688d3938dfb.png">

## Testing

No

## Docs

N/A