### PR TITLE
Prevent TS extension from overwriting open docs

### DIFF
--- a/.changeset/friendly-owls-kick.md
+++ b/.changeset/friendly-owls-kick.md
@@ -1,0 +1,5 @@
+---
+"@astrojs/language-server": patch
+---
+
+Fixes issue with errors not going away after fixing them

--- a/packages/language-server/src/check.ts
+++ b/packages/language-server/src/check.ts
@@ -24,7 +24,8 @@ export class AstroCheck {
       languageId: 'astro',
       version: 0,
       text: doc.text,
-      uri: doc.uri
+      uri: doc.uri,
+      overrideText: true
     });
     this.docManager.markAsOpenedInClient(doc.uri);
   }

--- a/packages/language-server/src/core/documents/DocumentManager.ts
+++ b/packages/language-server/src/core/documents/DocumentManager.ts
@@ -18,11 +18,12 @@ export class DocumentManager {
     return this.documents.get(normalizeUri(uri));
   }
 
-  openDocument(textDocument: TextDocumentItem) {
+  openDocument(textDocument: TextDocumentItem & { overrideText: boolean }) {
     let document: Document;
     if (this.documents.has(textDocument.uri)) {
       document = this.get(textDocument.uri) as Document;
-      document.setText(textDocument.text);
+      if(textDocument.overrideText)
+        document.setText(textDocument.text);
     } else {
       document = this.createDocument(textDocument);
       this.documents.set(normalizeUri(textDocument.uri), document);

--- a/packages/language-server/src/plugins/typescript/DocumentSnapshot.ts
+++ b/packages/language-server/src/plugins/typescript/DocumentSnapshot.ts
@@ -50,12 +50,12 @@ export interface DocumentSnapshot extends ts.IScriptSnapshot {
   getFullText(): string;
 }
 
-export const createDocumentSnapshot = (filePath: string, currentText: string | null, createDocument?: (_filePath: string, text: string) => Document): DocumentSnapshot => {
+export const createDocumentSnapshot = (filePath: string, currentText: string | null, createDocument?: (_filePath: string, text: string, overrideText: boolean) => Document): DocumentSnapshot => {
   const text = currentText || (ts.sys.readFile(filePath) ?? '');
 
   if (isAstroFilePath(filePath)) {
     if (!createDocument) throw new Error('Astro documents require the "createDocument" utility to be provided');
-    const snapshot = new AstroDocumentSnapshot(createDocument(filePath, text));
+    const snapshot = new AstroDocumentSnapshot(createDocument(filePath, text, currentText !== null));
     return snapshot;
   }
 

--- a/packages/language-server/src/plugins/typescript/LanguageServiceManager.ts
+++ b/packages/language-server/src/plugins/typescript/LanguageServiceManager.ts
@@ -42,13 +42,14 @@ export class LanguageServiceManager {
     }, '');
   }
 
-  private createDocument = (fileName: string, content: string) => {
+  private createDocument = (fileName: string, content: string, overrideText: boolean) => {
     const uri = pathToUrl(fileName);
     const document = this.docManager.openDocument({
       languageId: 'astro',
       version: 0,
       text: content,
       uri,
+      overrideText,
     });
     return document;
   };

--- a/packages/language-server/src/plugins/typescript/languageService.ts
+++ b/packages/language-server/src/plugins/typescript/languageService.ts
@@ -20,7 +20,7 @@ export interface LanguageServiceContainer {
 
 export interface LanguageServiceDocumentContext {
   getWorkspaceRoot(fileName: string): string;
-  createDocument: (fileName: string, content: string) => Document;
+  createDocument: (fileName: string, content: string, overrideText: boolean) => Document;
 }
 
 export async function getLanguageService(path: string, workspaceUris: string[], docContext: LanguageServiceDocumentContext): Promise<LanguageServiceContainer> {

--- a/packages/language-server/src/server.ts
+++ b/packages/language-server/src/server.ts
@@ -88,7 +88,7 @@ export function startServer() {
 
   // Documents
   connection.onDidOpenTextDocument((evt) => {
-    docManager.openDocument(evt.textDocument);
+    docManager.openDocument(Object.assign({ overrideText: true }, evt.textDocument));
     docManager.markAsOpenedInClient(evt.textDocument.uri);
   });
 


### PR DESCRIPTION
## Changes

- TypeScript has its own snapshot manager
- When it doesn't have an existing snapshot it creates a new one by using the text from the filesystem.
- If you've already edited the document before TS creates its first snapshot (for something like hover), the document will be out of sync going forward. Depending on what you edited this could cause chaos.
- This fixes it! Prefers using existing documents in this particular case.
