### PR TITLE
Support Astro code blocks in Markdown

### DIFF
--- a/packages/vscode/package.json
+++ b/packages/vscode/package.json
@@ -233,6 +233,16 @@
           "meta.embedded.block.csharp": "csharp",
           "meta.embedded.block.fsharp": "fsharp"
         }
+      },
+      {
+        "scopeName": "text.html.markdown.astro",
+        "path": "./syntaxes/astro.inject-to-markdown.tmLanguage.json",
+        "injectTo": [
+          "text.html.markdown"
+        ],
+        "embeddedLanguages": {
+          "meta.embedded.block.css": "astro"
+        }
       }
     ]
   }

--- a/packages/vscode/syntaxes/astro.inject-to-markdown.tmLanguage.json
+++ b/packages/vscode/syntaxes/astro.inject-to-markdown.tmLanguage.json
@@ -1,0 +1,87 @@
+{
+	"name": "Astro Markdown Block",
+	"scopeName": "text.html.markdown.astro",
+	"injectionSelector": "L:text.html.markdown",
+	"patterns": [
+		{
+			"include": "#fenced_code_block_astro"
+		}
+	],
+	"repository": {
+		"fenced_code_block_astro": {
+			"name": "markup.fenced_code.block.markdown",
+			"begin": "(^|\\G)(\\s*)(`{3,}|~{3,})\\s*(?i:(astro)((\\s+|:|\\{)[^`~]*)?$)",
+			"beginCaptures": {
+				"3": {
+					"name": "punctuation.definition.markdown"
+				},
+				"4": {
+					"name": "fenced_code.block.language.markdown"
+				},
+				"5": {
+					"name": "fenced_code.block.language.attributes.markdown"
+				}
+			},
+			"end": "(^|\\G)(\\2|\\s{0,3})(\\3)\\s*$",
+			"endCaptures": {
+				"3": {
+					"name": "punctuation.definition.markdown"
+				}
+			},
+			"patterns": [
+				{
+					"begin": "(^|\\G)(\\s*)(.*)",
+					"while": "(^|\\G)(?!\\s*([`~]{3,})\\s*$)",
+					"contentName": "meta.embedded.block.astro",
+					"patterns": [
+						{
+							"begin": "\\G",
+							"end": "(?<=\\s*([`~]{3,})\\s*$)(^|\\G)",
+							"patterns": [
+								{
+									"include": "#frontmatter"
+								},
+								{
+									"begin": "^(?=\\S)|(?!\\G)",
+									"end": "(?<=\\s*([`~]{3,})\\s*$)(^|\\G)",
+									"patterns": [
+										{
+											"include": "#astro"
+										}
+									]
+								}
+							]
+						}
+					]
+				}
+			]
+		},
+		"frontmatter": {
+			"begin": "^-{3}\\s*$",
+			"beginCaptures": {
+				"0": {
+					"name": "punctuation.definition.tag.xi.begin.t"
+				}
+			},
+			"end": "^-{3}\\s*$",
+			"endCaptures": {
+				"0": {
+					"name": "punctuation.definition.tag.xi.end.t"
+				}
+			},
+			"contentName": "meta.embedded.block.frontmatter",
+			"patterns": [
+				{
+					"include": "source.tsx"
+				}
+			]
+		},
+		"astro": {
+			"patterns": [
+				{
+					"include": "text.html.astro"
+				}
+			]
+		}
+	}
+}


### PR DESCRIPTION
## Changes

This adds support for `astro` fenced codeblocks in Markdown.

## Testing

This was tested by looking at Astro fenced codeblocks markup in Markdown files.

## Docs

bug fix only