### PR TITLE
fix: ignore tsconfig setting files

### DIFF
--- a/.changeset/fall-leaves-fall.md
+++ b/.changeset/fall-leaves-fall.md
@@ -1,0 +1,5 @@
+---
+"@astrojs/language-server": minor
+---
+
+Ignore tsconfig setting files

--- a/packages/language-server/src/plugins/typescript/languageService.ts
+++ b/packages/language-server/src/plugins/typescript/languageService.ts
@@ -55,18 +55,7 @@ async function createLanguageService(tsconfigPath: string, workspaceRoot: string
     },
   };
 
-  let configJson = (tsconfigPath && ts.readConfigFile(tsconfigPath, ts.sys.readFile).config) || getDefaultJsConfig();
-  if (!configJson.extends) {
-    configJson = Object.assign(
-      {
-        exclude: getDefaultExclude(),
-      },
-      configJson
-    );
-  }
-
-  // Delete include so that astro files don't get excluded.
-  delete configJson.include;
+  const configJson = getDefaultJsConfig();
 
   const existingCompilerOptions: ts.CompilerOptions = {
     jsx: ts.JsxEmit.Preserve,
@@ -174,22 +163,19 @@ async function createLanguageService(tsconfigPath: string, workspaceRoot: string
   }
 }
 
-/**
- * This should only be used when there's no jsconfig/tsconfig at all
- */
 function getDefaultJsConfig(): {
-  compilerOptions: ts.CompilerOptions;
-  include: string[];
+   compilerOptions: ts.CompilerOptions;
+   exclude: string[];
 } {
-  let compilerOptions = {
-    maxNodeModuleJsDepth: 2,
-    allowSyntheticDefaultImports: true,
-    allowJs: true
-  };
-  return {
-    compilerOptions,
-    include: ['src'],
-  };
+   let compilerOptions = {
+      maxNodeModuleJsDepth: 2,
+      allowSyntheticDefaultImports: true,
+      allowJs: true,
+   };
+   return {
+      compilerOptions,
+      exclude: getDefaultExclude(),
+   };
 }
 
 function getDefaultExclude() {


### PR DESCRIPTION
Astro should not be reading the tsconf settings file.  This causes issues  such as `strict: true` causing ts errors like:

`JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.`

RE: https://discord.com/channels/830184174198718474/845451724738265138/895704312544653353

Closes #91.

## Changes

- Stops using the `tsconfig.json` as part of the default configuration for the Astro language tools

## Testing

- Tested manually be using `strict: true` in the `tsconfig.json` file before changes.
  - The Visual Studio Code editor highlighted all the JSX code with the  `JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.` error
- After changes, Code did not produce the error.
- Also manually tested creating constants, using Astro props etc to ensure TypeScript still worked properly in `.astro` files.  

## Docs

- No doc changes are required.

cc: @matthewp 