### PR TITLE
Bump TypeScript

### DIFF
--- a/.changeset/plenty-ladybugs-fry.md
+++ b/.changeset/plenty-ladybugs-fry.md
@@ -1,0 +1,5 @@
+---
+"@astrojs/language-server": patch
+---
+
+Bump TypeScript from 4.3.1-rc to 4.5.1-rc

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "prettier": "^2.2.1",
     "svelte": "^3.38.0",
     "tiny-glob": "^0.2.8",
-    "typescript": "^4.2.4",
+    "typescript": "^4.5.1-rc",
     "uvu": "^0.5.1"
   },
   "engines": {

--- a/packages/language-server/package.json
+++ b/packages/language-server/package.json
@@ -23,7 +23,7 @@
     "lodash": "^4.17.21",
     "source-map": "^0.7.3",
     "ts-morph": "^12.0.0",
-    "typescript": "^4.3.1-rc",
+    "typescript": "^4.5.1-rc",
     "vscode-css-languageservice": "^5.1.1",
     "vscode-emmet-helper": "2.1.2",
     "vscode-html-languageservice": "^3.0.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -9250,10 +9250,10 @@ typescript@*:
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.4.2.tgz#6d618640d430e3569a1dfb44f7d7e600ced3ee86"
   integrity sha512-gzP+t5W4hdy4c+68bfcv0t400HVJMMd2+H9B7gae1nQlBzCqvrXX+6GL/b3GAgyTH966pzrZ70/fRjwAtZksSQ==
 
-typescript@^4.2.4, typescript@^4.3.1-rc:
-  version "4.3.5"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.3.5.tgz#4d1c37cc16e893973c45a06886b7113234f119f4"
-  integrity sha512-DqQgihaQ9cUrskJo9kIyW/+g0Vxsk8cDtZ52a3NGh0YNTfpUSArXSohyUGnvbPazEPLu398C0UxmKSOrPumUzA==
+typescript@^4.5.1-rc:
+  version "4.5.1-rc"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.5.1-rc.tgz#02155eaa0579d11babb2a55dcbd796948a994bb3"
+  integrity sha512-tQBWW1DCFqweyhSzsAUSFgssJ3uuRBh0zyOkRV4CaFF2rMBkGU0I+MqPMch0qhGCUGXjOW7FgMrbQLS6PE3Z6Q==
 
 uglify-js@^3.1.4:
   version "3.14.1"


### PR DESCRIPTION
## Changes

This PR bumps TypeScript from `4.3.1-rc` to `4.5.1-rc` in the language extension.

To ensure a consistent developer experience, it bumps the project root to match the language extension.

## Testing

bump only

## Docs

bump only